### PR TITLE
added a GHA to check if the project builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 18.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run TypeScript build
+        run: npm run build:typescript

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc && npm run sentry:sourcemaps",
+    "build:typescript": "tsc",
     "start": "node dist/index.js",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org navitools --project backup ./dist && sentry-cli sourcemaps upload --org navitools --project backup ./dist"
   },


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building the project and adds a supporting npm script for running the TypeScript build. These changes automate the build process and ensure that TypeScript compilation is run consistently in CI for pushes and pull requests.

Continuous Integration setup:

* Added a new workflow file `.github/workflows/build.yml` to automate building the project on pushes to `main` and `develop` branches, and on pull requests to `main`. The workflow checks out the code, sets up Node.js 18.x, installs dependencies, and runs the TypeScript build.

NPM scripts update:

* Added a new `build:typescript` script to `package.json` to run the TypeScript compiler (`tsc`) independently of other build steps, supporting the CI workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a continuous integration build workflow that runs on pushes and pull requests to ensure TypeScript projects compile successfully.
  * Added a dedicated TypeScript-only build task to align local and CI build steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->