### PR TITLE
Added support for MariaDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,6 @@ COPY --from=build /root/dist ./dist
 ARG PG_VERSION='16'
 
 RUN apk add --update --no-cache postgresql${PG_VERSION}-client --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main && \
-    apk add --update --no-cache nodejs npm zip
+    apk add --update --no-cache mysql-client nodejs npm zip
 
-CMD pg_isready --dbname=$BACKUP_DATABASE_URL && \
-    pg_dump --version && \
-    node dist/index.js
+CMD node dist/index.js

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Automatically generates backups to an [S3 Bucket](https://s3.console.aws.amazon.com/s3/)
 
+Supports both PostgreSQL and MariaDB databases.
+
 ## Setup
 
 Requires the following variables:
@@ -11,17 +13,39 @@ AWS_SECRET_ACCESS_KEY=
 AWS_S3_BUCKET=
 AWS_S3_REGION=
 BACKUP_DATABASE_URL=
-ROLLBAR_ACCESS_TOKEN=
+DATABASE_TYPE=postgres  # or 'mariadb'
+SERVICE_NAME=
+SENTRY_DSN=
+```
+
+### Database Connection URLs
+
+For PostgreSQL:
+```
+postgresql://username:password@host:port/database
+```
+
+For MariaDB:
+```
+mysql://username:password@host:port/database
 ```
 
 ## How to restore
 
 Download the zip file and uncompress it.
 
-You'll have a file that ends in `.dump` (ex: `my-backup.dump`)
+You'll have a file that ends in `.sql` (ex: `my-backup.sql`)
 
-Run the following command on the same directory as the `.dump` file exist:
+### PostgreSQL Restore
+Run the following command on the same directory as the `.sql` file exists:
 
 ```sh
-psql -U <username> -h <host> -d <DB-Name> -f my-backup.dump
+psql -U <username> -h <host> -d <DB-Name> -f my-backup.sql
+```
+
+### MariaDB Restore
+Run the following command on the same directory as the `.sql` file exists:
+
+```sh
+mysql -u <username> -p -h <host> <DB-Name> < my-backup.sql
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "@sentry/profiling-node": "^1.2.1",
         "dotenv": "^16.3.1",
         "envsafe": "^2.0.3",
-        "filesize": "^10.1.0"
+        "filesize": "^10.1.0",
+        "mysql2": "^3.6.0"
       },
       "devDependencies": {
         "@types/node": "^20.4.1",
@@ -1530,6 +1531,15 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -1549,6 +1559,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/detect-libc": {
@@ -1617,6 +1636,15 @@
         "node": ">= 10.4.0"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -1633,8 +1661,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -1646,6 +1672,12 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -1671,10 +1703,72 @@
         "lie": "3.1.1"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.2.tgz",
+      "integrity": "sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/mysql2": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.14.3.tgz",
+      "integrity": "sha512-fD6MLV8XJ1KiNFIF0bS7Msl8eZyhlTDCDl75ajU5SJtpdx9ZPEACulJcqJWr1Y8OYyxsFc4j3+nflpmhxCU5aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/node-abi": {
       "version": "3.75.0",
@@ -1723,9 +1817,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -1737,6 +1829,20 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/strnum": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@sentry/profiling-node": "^1.2.1",
     "dotenv": "^16.3.1",
     "envsafe": "^2.0.3",
-    "filesize": "^10.1.0"
+    "filesize": "^10.1.0",
+    "mysql2": "^3.6.0"
   }
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -9,6 +9,11 @@ export const env = envsafe({
   BACKUP_DATABASE_URL: str({
     desc: 'The connection string of the database to backup.'
   }),
+  DATABASE_TYPE: str({
+    desc: 'The type of database to backup (postgres or mariadb)',
+    choices: ['postgres', 'mariadb'],
+    default: 'postgres'
+  }),
   AWS_S3_ENDPOINT: str({
     desc: 'The S3 custom endpoint you want to use.',
     default: '',

--- a/src/test-config.ts
+++ b/src/test-config.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * Test script to validate MariaDB backup functionality
+ */
+
+import { env } from './env';
+
+console.log('Testing MariaDB backup configuration...');
+console.log('Database type:', env.DATABASE_TYPE);
+
+if (env.DATABASE_TYPE === 'mariadb') {
+    console.log('✓ MariaDB database type configured');
+} else if (env.DATABASE_TYPE === 'postgres') {
+    console.log('✓ PostgreSQL database type configured');
+} else {
+    console.log('✗ Unsupported database type:', env.DATABASE_TYPE);
+    process.exit(1);
+}
+
+console.log('Database URL:', env.BACKUP_DATABASE_URL.replace(/:[^@]*@/, ':***@'));
+console.log('Service name:', env.SERVICE_NAME);
+console.log('All environment variables validated successfully!');


### PR DESCRIPTION
This pull request adds support for backing up both PostgreSQL and MariaDB databases, improving flexibility and usability. The changes include updates to documentation, environment variable configuration, dependency management, and the backup logic to handle both database types.

**Database support enhancements:**

* Added support for MariaDB backups alongside PostgreSQL, including new logic in `src/backup.ts` to handle both types based on the `DATABASE_TYPE` environment variable. [[1]](diffhunk://#diff-a8dbb673e473f1aa7079ff61a528f5ae583f12700113477454fa344ac1fa99feL36-R58) [[2]](diffhunk://#diff-a8dbb673e473f1aa7079ff61a528f5ae583f12700113477454fa344ac1fa99feR86-R129) [[3]](diffhunk://#diff-00ee6a506727e42b3fb03361b8216c805ede24dc3985d237de852a73bda59f30R12-R16)
* Updated Dockerfile to install `mysql-client` for MariaDB support and removed PostgreSQL-specific startup commands.
* Added the `mysql2` package to dependencies for MariaDB compatibility.

**Documentation and configuration updates:**

* Improved `README.md` to document MariaDB support, updated environment variables, and provided detailed instructions for both PostgreSQL and MariaDB backup and restore processes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R50)
* Added a test script `src/test-config.ts` to validate the backup configuration for both database types.

**Backup process improvements:**

* Modified backup file naming and logging to reflect the database type and use `.sql` extension, ensuring clarity in backup outputs. [[1]](diffhunk://#diff-a8dbb673e473f1aa7079ff61a528f5ae583f12700113477454fa344ac1fa99feL81-R151) [[2]](diffhunk://#diff-a8dbb673e473f1aa7079ff61a528f5ae583f12700113477454fa344ac1fa99feL99-R164)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added MariaDB backup support alongside PostgreSQL, selectable via an environment variable. Backup filenames now include database type with clearer logs.
- Documentation
  - Updated setup, environment variables, connection URL examples, and restore instructions for both PostgreSQL and MariaDB using .sql files.
- Chores
  - Streamlined container startup and runtime dependencies; replaced PostgreSQL client with MySQL client.
- Dependencies
  - Added MySQL driver.
- Tests
  - Introduced a config validation script to verify multi-database environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->